### PR TITLE
fixes #22 enable database iam authentication

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -13,3 +13,5 @@ data "aws_route53_zone" "apiary_zone" {
   name   = "${var.apiary_domain_name}"
   vpc_id = "${var.vpc_id}"
 }
+
+data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,44 @@ resource "aws_iam_role" "apiary_task_readwrite" {
 EOF
 }
 
+resource "aws_iam_role_policy" "rds_for_ecs_readonly" {
+  name = "rds"
+  role = "${aws_iam_role.apiary_task_readonly.id}"
+
+  policy = <<EOF
+{
+  "Version" : "2012-10-17",
+  "Statement" :
+  [
+    {
+      "Effect" : "Allow",
+      "Action" : ["rds-db:connect"],
+      "Resource" : ["arn:aws:rds-db:${var.aws_region}:${data.aws_caller_identity.current.account_id}:dbuser:${aws_rds_cluster.apiary_cluster.cluster_resource_id}/iamro"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "rds_for_ecs_task_readwrite" {
+  name = "rds"
+  role = "${aws_iam_role.apiary_task_readwrite.id}"
+
+  policy = <<EOF
+{
+  "Version" : "2012-10-17",
+  "Statement" :
+  [
+    {
+      "Effect" : "Allow",
+      "Action" : ["rds-db:connect"],
+      "Resource" : ["arn:aws:rds-db:${var.aws_region}:${data.aws_caller_identity.current.account_id}:dbuser:${aws_rds_cluster.apiary_cluster.cluster_resource_id}/iamrw"]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy" "s3_data_for_ecs_task_readwrite" {
   count = "${length(var.apiary_data_buckets)}"
   name  = "s3-data-${count.index}"

--- a/scripts/db-iam-auth.sh
+++ b/scripts/db-iam-auth.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+MYSQL_OPTIONS="-h $1 --user=$2 --password=$3"
+RWUSER="iamrw"
+ROUSER="iamro"
+
+echo "CREATE USER $RWUSER IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';"|mysql $MYSQL_OPTIONS
+echo "GRANT ALL ON \`%\`.* TO ${RWUSER}@\`%\`;"|mysql $MYSQL_OPTIONS
+
+echo "CREATE USER $ROUSER IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';"|mysql $MYSQL_OPTIONS
+echo "GRANT SELECT ON \`%\`.* TO ${ROUSER}@\`%\`;"|mysql $MYSQL_OPTIONS

--- a/templates/apiary-hms-readonly.json
+++ b/templates/apiary-hms-readonly.json
@@ -38,6 +38,10 @@
         "value": "${hms_heapsize}"
      },
      {
+        "name": "AWS_REGION",
+        "value": "${region}"
+     },
+     {
         "name": "VAULT_ADDR",
         "value": "${vault_addr}"
      },

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -42,6 +42,10 @@
         "value": "${hms_heapsize}"
      },
      {
+        "name": "AWS_REGION",
+        "value": "${region}"
+     },
+     {
         "name": "VAULT_ADDR",
         "value": "${vault_addr}"
      },


### PR DESCRIPTION
enables IAM suport in RDS
creates mysql users with AWSAuthenticationPlugin


Note: not cleaning up vault credentials and mysql static users yet as credentials generated with IAM are temporary and mysql jdbc driver doesn't have proper support for IAM, following is one of related jiras.
https://jira.mariadb.org/browse/CONJ-518