### PR TITLE
fixes #24, configure apiary datalake using hive schema names instead …

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -5,7 +5,7 @@
  */
 
 data "template_file" "s3_widgets" {
-  count = "${length(var.apiary_data_buckets)}"
+  count = "${length(local.apiary_data_buckets)}"
 
   template = <<EOF
        {
@@ -87,7 +87,7 @@ data "template_file" "s3_widgets" {
 EOF
 
   vars {
-    bucket_name = "${var.apiary_data_buckets[count.index]}"
+    bucket_name = "${local.apiary_data_buckets[count.index]}"
   }
 }
 

--- a/common.tf
+++ b/common.tf
@@ -2,6 +2,7 @@ locals {
   instance_alias         = "${ var.instance_name == "" ? "apiary" : format("apiary-%s",var.instance_name) }"
   vault_path             = "${ var.vault_path == "" ? format("secret/%s-%s",local.instance_alias,var.aws_region) : var.vault_path }"
   enable_route53_records = "${ var.apiary_domain_name == "" ? "0" : "1" }"
+  apiary_data_buckets           = "${ formatlist("%s-%s-%s-%s",local.instance_alias,data.aws_caller_identity.current.account_id,var.aws_region,var.apiary_managed_schemas) }"
 }
 
 data "aws_vpc" "apiary_vpc" {

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "s3_data_for_ecs_task_readwrite" {
-  count = "${length(var.apiary_data_buckets)}"
+  count = "${length(local.apiary_data_buckets)}"
   name  = "s3-data-${count.index}"
   role  = "${aws_iam_role.apiary_task_readwrite.id}"
 
@@ -137,8 +137,8 @@ resource "aws_iam_role_policy" "s3_data_for_ecs_task_readwrite" {
                               "s3:PutObjectVersionTagging"
                             ],
                   "Resource": [
-                                "arn:aws:s3:::${element(var.apiary_data_buckets, count.index)}/*",
-                                "arn:aws:s3:::${element(var.apiary_data_buckets, count.index)}"
+                                "arn:aws:s3:::${element(local.apiary_data_buckets, count.index)}/*",
+                                "arn:aws:s3:::${element(local.apiary_data_buckets, count.index)}"
                               ]
                 }
               ]
@@ -182,7 +182,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "s3_data_for_ecs_task_readonly" {
-  count = "${length(var.apiary_data_buckets)}"
+  count = "${length(local.apiary_data_buckets)}"
   name  = "s3-data-${count.index}"
   role  = "${aws_iam_role.apiary_task_readonly.id}"
 
@@ -197,8 +197,8 @@ resource "aws_iam_role_policy" "s3_data_for_ecs_task_readonly" {
                               "s3:List*"
                             ],
                   "Resource": [
-                                "arn:aws:s3:::${element(var.apiary_data_buckets, count.index)}/*",
-                                "arn:aws:s3:::${element(var.apiary_data_buckets, count.index)}"
+                                "arn:aws:s3:::${element(local.apiary_data_buckets, count.index)}/*",
+                                "arn:aws:s3:::${element(local.apiary_data_buckets, count.index)}"
                               ]
                 }
               ]
@@ -252,6 +252,8 @@ data "template_file" "hms_readwrite" {
     vault_path         = "${local.vault_path}"
     log_level          = "${var.hms_log_level}"
     nofile_ulimit      = "${var.hms_nofile_ulimit}"
+    managed_schemas    = "${join(",",var.apiary_managed_schemas)}"
+    instance_name      = "${local.instance_alias}"
   }
 }
 

--- a/output.tf
+++ b/output.tf
@@ -17,7 +17,7 @@ output "mysql_db_dns" {
 }
 
 output "apiary_data_buckets" {
-  value = "${var.apiary_data_buckets}"
+  value = "${local.apiary_data_buckets}"
 }
 
 output "apiary_metadata_updates_sns" {

--- a/s3.tf
+++ b/s3.tf
@@ -8,12 +8,12 @@
 ### Apiary S3 policy template
 ##
 data "template_file" "bucket_policy" {
-  count    = "${length(var.apiary_data_buckets)}"
+  count    = "${length(local.apiary_data_buckets)}"
   template = "${file("${path.module}/templates/apiary_bucket_policy.json")}"
 
   vars {
     customer_principal = "${join("\",\"", formatlist("arn:aws:iam::%s:root",var.apiary_customer_accounts))}"
-    bucket_name        = "${var.apiary_data_buckets[count.index]}"
+    bucket_name        = "${local.apiary_data_buckets[count.index]}"
   }
 }
 
@@ -21,8 +21,8 @@ data "template_file" "bucket_policy" {
 ### Apiary S3 data buckets
 ##
 resource "aws_s3_bucket" "apiary_data_bucket" {
-  count         = "${length(var.apiary_data_buckets)}"
-  bucket        = "${element(var.apiary_data_buckets, count.index)}"
+  count         = "${length(local.apiary_data_buckets)}"
+  bucket        = "${element(local.apiary_data_buckets, count.index)}"
   acl           = "private"
   request_payer = "BucketOwner"
   policy        = "${data.template_file.bucket_policy.*.rendered[count.index]}"
@@ -30,6 +30,6 @@ resource "aws_s3_bucket" "apiary_data_bucket" {
 
   logging {
     target_bucket = "${var.apiary_log_bucket}"
-    target_prefix = "${var.apiary_log_prefix}${var.apiary_data_buckets[count.index]}/"
+    target_prefix = "${var.apiary_log_prefix}${local.apiary_data_buckets[count.index]}/"
   }
 }

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -46,6 +46,14 @@
         "value": "${region}"
      },
      {
+        "name": "HIVE_DBS",
+        "value": "${managed_schemas}"
+     },
+     {
+        "name": "INSTANCE_NAME",
+        "value": "${instance_name}"
+     },
+     {
         "name": "VAULT_ADDR",
         "value": "${vault_addr}"
      },

--- a/variables.tf
+++ b/variables.tf
@@ -73,8 +73,8 @@ variable "apiary_log_prefix" {
   default     = ""
 }
 
-variable "apiary_data_buckets" {
-  description = "buckets that apiary can serve data from"
+variable "apiary_managed_schemas" {
+  description = "schema names from which s3 bucket names will be derived,corresponding s3 bucket will be named as apiary_instance-aws_account-aws_region-schema_name"
   type        = "list"
   default     = []
 }


### PR DESCRIPTION
derives managed bucket names from schema names.
automatically create hive databases pointing to those buckets.

Note: 
  This doesn't change anything related to external_data_buckets
