### PR TITLE
configure sns policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,25 @@ resource "aws_iam_role_policy" "rds_for_ecs_task_readwrite" {
 EOF
 }
 
+resource "aws_iam_role_policy" "sns_for_ecs_task_readwrite" {
+  name = "sns"
+  role = "${aws_iam_role.apiary_task_readwrite.id}"
+
+  policy = <<EOF
+{
+  "Version" : "2012-10-17",
+  "Statement" :
+  [
+    {
+      "Effect" : "Allow",
+      "Action" : ["SNS:Publish"],
+      "Resource" : ["${aws_sns_topic.apiary_metadata_updates.arn}"]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy" "s3_data_for_ecs_task_readwrite" {
   count = "${length(local.apiary_data_buckets)}"
   name  = "s3-data-${count.index}"

--- a/sns.tf
+++ b/sns.tf
@@ -10,4 +10,17 @@ resource "aws_sns_topic" "apiary_ops_sns" {
 
 resource "aws_sns_topic" "apiary_metadata_updates" {
   name = "${local.instance_alias}-metadata-updates"
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[{
+        "Effect": "Allow",
+        "Principal": {
+            "AWS": [ "${join("\",\"", formatlist("arn:aws:iam::%s:root",var.apiary_customer_accounts))}" ]
+        },
+        "Action": [ "SNS:Subscribe", "SNS:Receive" ],
+        "Resource": "arn:aws:sns:*:*:${local.instance_alias}-metadata-updates"
+    }]
+}
+POLICY
 }


### PR DESCRIPTION
configure sns policy to allow readwrite task to publish and consumers to subscribe to metadata sns topic