### PR TITLE
fixes #56, Add output.tf

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+output "hms_readonly_dns" {
+  value = "${aws_lb.apiary_hms_readonly_lb.dns_name}"
+}
+
+output "hms_readwrite_dns" {
+  value = "${aws_lb.apiary_hms_readwrite_lb.dns_name}"
+}
+
+output "mysql_db_dns" {
+  value = "${aws_rds_cluster.apiary_cluster.endpoint}"
+}
+
+output "apiary_data_buckets" {
+  value = "${local.apiary_data_buckets}"
+}


### PR DESCRIPTION
`terraform init` runs successfully.

```
apiary-metastore$ terraform init
Initializing modules...
- module.apiary-metastore
- module.hcom-tags

Initializing the backend...

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 1.31"
* provider.null: version = "~> 1.0"
* provider.random: version = "~> 1.3"
* provider.template: version = "~> 1.0"
* provider.vault: version = "~> 1.1"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

```