### PR TITLE
Fix k8s read-only metastore to use RDS reader instance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.12.4] - 2022-06-03
+### Fixed
+- Fix k8s read-only metastore to use RDS reader instance.
+
 ## [6.12.3] - 2022-06-01
 ### Fixed
 - Fixed SM policy & templates for resource apiary_mysql_master_credentials when external_database_host is in use.

--- a/k8s-readonly.tf
+++ b/k8s-readonly.tf
@@ -93,7 +93,7 @@ resource "kubernetes_deployment" "apiary_hms_readonly" {
           }
           env {
             name  = "MYSQL_DB_HOST"
-            value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.endpoint) : var.external_database_host
+            value = var.external_database_host == "" ? join("", aws_rds_cluster.apiary_cluster.*.reader_endpoint) : var.external_database_host
           }
           env {
             name  = "MYSQL_DB_NAME"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues