### PR TITLE
fix: added LakeFormation permissions for glue stats service role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.12.7] - 2026-04-13
+### Added
+- Added LakeFormation permissions for `glue_stats_service_role` on Glue databases and tables.
+
 ## [7.12.6] - 2026-01-22
 ### Added
 - Added var `apiary_managed_s3_logs_queue_arn` to support use existing SQS queue for s3 logs bucket data event.

--- a/lf.tf
+++ b/lf.tf
@@ -324,6 +324,34 @@ resource "aws_lakeformation_permissions" "catalog_producer_system_permissions" {
 }
 
 
+#glue stats service role permissions
+resource "aws_lakeformation_permissions" "glue_stats_service_role_db_permissions" {
+  for_each = var.enable_glue_stats && var.disable_glue_db_init && var.create_lf_resource ? {
+    for schema in local.schemas_info : "${schema["schema_name"]}" => schema
+  } : {}
+
+  principal   = aws_iam_role.glue_stats_service_role[0].arn
+  permissions = ["DESCRIBE"]
+
+  database {
+    name = aws_glue_catalog_database.apiary_glue_database[each.key].name
+  }
+}
+
+resource "aws_lakeformation_permissions" "glue_stats_service_role_tbl_permissions" {
+  for_each = var.enable_glue_stats && var.disable_glue_db_init && var.create_lf_resource ? {
+    for schema in local.schemas_info : "${schema["schema_name"]}" => schema
+  } : {}
+
+  principal   = aws_iam_role.glue_stats_service_role[0].arn
+  permissions = ["ALL", "DESCRIBE"]
+
+  table {
+    database_name = aws_glue_catalog_database.apiary_glue_database[each.key].name
+    wildcard      = true
+  }
+}
+
 resource "aws_iam_role" "lf_data_access" {
   count = var.create_lf_resource && var.create_lf_data_access_role ? 1 : 0
   name  = "${local.instance_alias}-lf-data-access-role-${var.aws_region}"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues