### PR TITLE
feat: add LakeFormation table permissions for Glue stats vendor role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.12.8] - 2026-04-15
+### Added
+- Added var `create_glue_stats_vendor_role_tbl_permissions` to create LakeFormation table permissions (`DESCRIBE`, `INSERT`, `DELETE`) for the Glue stats service role on all schemas.
+
 ## [7.12.7] - 2026-04-13
 ### Added
 - Added LakeFormation permissions for `glue_stats_service_role` on Glue databases and tables.

--- a/lf.tf
+++ b/lf.tf
@@ -102,9 +102,9 @@ resource "aws_lakeformation_permissions" "hms_sys_loc_permissions" {
 }
 
 resource "aws_lakeformation_permissions" "data_location_access_permissions" {
-    for_each = var.disable_glue_db_init && var.create_lf_resource ? {
-      for schema in local.catalog_data_location_access_producer_schemas : "${schema["schema_name"]}-${schema["producer_arn"]}"  => schema
-    } : {}
+  for_each = var.disable_glue_db_init && var.create_lf_resource ? {
+    for schema in local.catalog_data_location_access_producer_schemas : "${schema["schema_name"]}-${schema["producer_arn"]}" => schema
+  } : {}
 
   principal   = each.value.producer_arn
   permissions = ["DATA_LOCATION_ACCESS"]
@@ -170,7 +170,7 @@ resource "aws_lakeformation_permissions" "readonly_client_permissions" {
   }) : {}
 
   principal   = each.value.client_arn
-  permissions = ["DESCRIBE","SELECT"]
+  permissions = ["DESCRIBE", "SELECT"]
 
   table {
     database_name = aws_glue_catalog_database.apiary_glue_database[each.value.schema_name].name
@@ -345,6 +345,18 @@ resource "aws_lakeformation_permissions" "glue_stats_service_role_tbl_permission
 
   principal   = aws_iam_role.glue_stats_service_role[0].arn
   permissions = ["ALL", "DESCRIBE"]
+
+  table {
+    database_name = aws_glue_catalog_database.apiary_glue_database[each.key].name
+    wildcard      = true
+  }
+}
+
+resource "aws_lakeformation_permissions" "glue_stats_vendor_role_tbl_permissions" {
+  for_each = var.enable_glue_stats && var.create_lf_resource && var.create_glue_stats_vendor_role_tbl_permissions ? local.schemas_info_map : {}
+
+  principal   = aws_iam_role.lf_data_access[0].arn
+  permissions = ["DESCRIBE", "INSERT", "DELETE"]
 
   table {
     database_name = aws_glue_catalog_database.apiary_glue_database[each.key].name

--- a/variables.tf
+++ b/variables.tf
@@ -627,7 +627,7 @@ variable "lf_catalog_producer_arns" {
   default     = []
 }
 
-variable lf_catalog_data_location_access_producer_arns {
+variable "lf_catalog_data_location_access_producer_arns" {
   description = "AWS IAM role ARNs granted `DATA_LOCATION_ACCESS` permissions on all database s3 locations using LakeFormation. NOTE this permission is not granted by `lf_catalog_producer_arns`"
   type        = list(string)
   default     = []
@@ -1217,6 +1217,12 @@ variable "enable_splunk_logging" {
 
 variable "enable_glue_stats" {
   description = "Enable automatic Glue column statistics collection."
+  type        = bool
+  default     = false
+}
+
+variable "create_glue_stats_vendor_role_tbl_permissions" {
+  description = "Create LakeFormation table permissions (DESCRIBE, INSERT, DELETE) for the Glue stats service role on all schemas."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Added var `create_glue_stats_vendor_role_tbl_permissions` and corresponding `aws_lakeformation_permissions` resource granting DESCRIBE/INSERT/DELETE on all schema tables to the Glue stats service role in EGDP.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-data-lake/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues